### PR TITLE
fixed #3

### DIFF
--- a/lib/painter.dart
+++ b/lib/painter.dart
@@ -295,9 +295,9 @@ class SVGAPainter extends CustomPainter {
             this.videoItem.dynamicItem.dynamicDrawer[sprite.imageKey](
                 canvas, this.currentFrame);
           }
-          if (shape.hasTransform() || frameItem.hasClipPath()) {
+        }
+        if (shape.hasTransform() || frameItem.hasClipPath()) {
             canvas.restore();
-          }
         }
       });
       canvas.restore();


### PR DESCRIPTION
the canvas.save() and canvas.restore() in the `drawShape()` function weren't paired when `strokeWidth != null && strokeWidth > 0` fails. When we set the stroke to be transparent, the condition `strokeWidth != null && strokeWidth > 0` fails, and the canvas.restore() function that was inside the condition block wasn't called.

I've adjusted the `canvas.restore()` call to a proper position in this commit.
