### PR TITLE
fix setState error which is caused by calling listener with animation…

### DIFF
--- a/lib/player.dart
+++ b/lib/player.dart
@@ -63,14 +63,26 @@ class _SVGAImageState extends State<SVGAImage> {
   final bool clearsAfterStop;
 
   _SVGAImageState(this._animationController, {this.clearsAfterStop}) {
-    this._animationController.addListener(() {
+    this._animationController.addListener(_setState);
+    this._animationController.addStatusListener(_clearAnimation);
+  }
+
+  void _setState() {
+    if (mounted) {
       this.setState(() {});
-    });
-    this._animationController.addStatusListener((status) {
-      if (status == AnimationStatus.completed && this.clearsAfterStop) {
-        this._animationController.clear();
-      }
-    });
+    }
+  }
+  void _clearAnimation(AnimationStatus status) {
+    if (status == AnimationStatus.completed && this.clearsAfterStop) {
+      this._animationController.clear();
+    }
+  }
+
+  @override
+  void dispose() {
+    this._animationController.removeListener(_setState);
+    this._animationController.removeStatusListener(_clearAnimation);
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
fix setState error which is caused by calling listener with animatioController after SVGAImage state destruction.

detailed error log:

I/flutter (20706): Another exception was thrown: setState() called after dispose(): _SVGAImageState#ad7bb(lifecycle state: defunct, not mounted)