### PR TITLE
[bug]svga 在动态设置文本时，第一帧就把文本显示出来了，这里会导致文本显示的位置不对

### DIFF
--- a/lib/painter.dart
+++ b/lib/painter.dart
@@ -471,12 +471,14 @@ class SVGAPainter extends CustomPainter {
   }
 
   void drawText(SpriteEntity sprite, Canvas canvas, Size size) {
+
     if (this.videoItem.dynamicItem.dynamicText.length == 0) return;
     if (sprite.imageKey == null) return;
     if (this.videoItem.dynamicItem.dynamicHidden[sprite.imageKey] == true)
       return;
     if (this.videoItem.dynamicItem.dynamicText[sprite.imageKey] == null) return;
     final frameItem = sprite.frames[this.currentFrame];
+    if (frameItem.layout.width <= 0 || frameItem.layout.height <= 0) return;
     canvas.save();
     if (frameItem.hasTransform()) {
       canvas.transform(Float64List.fromList([


### PR DESCRIPTION
svga 在动态设置文本时，第一帧就把文本显示出来了，这里会导致文本显示的位置不对
原因：这一帧的 layout 还没有信息，即帧中还没有文本位置信息，导致文本不知道该往哪里放，就直接放在了左上角出，进而显示的位置不对
解决：等待帧中有文本位置信息时才画文本